### PR TITLE
chore: upgrade some packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ license = "Apache-2.0"
 description = "A rust client for GreptimeDB gRPC protocol"
 
 [dependencies]
-dashmap = "5.4"
+dashmap = "6.1"
 enum_dispatch = "0.3"
 futures = "0.3"
 futures-util  = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", tag = "v0.7.0" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", tag = "v0.9.0" }
 parking_lot = "0.12"
 prost = "0.12"
-rand = "0.8"
-snafu = "0.7"
+rand = "0.9"
+snafu = "0.8"
 tokio = { version = "1", features = ["rt", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { version = "0.11", features = ["tls", "tls-roots", "gzip", "zstd"] }
@@ -26,4 +26,4 @@ tonic-build = "0.9"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-derive-new = "0.5"
+derive-new = "0.7"

--- a/examples/ingest.rs
+++ b/examples/ingest.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
+
 use derive_new::new;
 
 use greptimedb_ingester::api::v1::*;

--- a/examples/stream_ingest.rs
+++ b/examples/stream_ingest.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
+
 use derive_new::new;
 
 use greptimedb_ingester::api::v1::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,38 +21,64 @@ use tonic::Status;
 #[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display("Invalid client tls config, {}", msg))]
-    InvalidTlsConfig { msg: String },
+    InvalidTlsConfig {
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Invalid config file path, {}", source))]
     InvalidConfigFilePath {
         source: io::Error,
+        #[snafu(implicit)]
         location: Location,
     },
 
     #[snafu(display("Failed to create gRPC channel, source: {}", source))]
     CreateChannel {
         source: tonic::transport::Error,
+        #[snafu(implicit)]
         location: Location,
     },
 
     #[snafu(display("Unknown proto column datatype: {}", datatype))]
-    UnknownColumnDataType { datatype: i32, location: Location },
+    UnknownColumnDataType {
+        datatype: i32,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Illegal GRPC client state: {}", err_msg))]
-    IllegalGrpcClientState { err_msg: String, location: Location },
+    IllegalGrpcClientState {
+        err_msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Missing required field in protobuf, field: {}", field))]
-    MissingField { field: String, location: Location },
+    MissingField {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     // Server error carried in Tonic Status's metadata.
     #[snafu(display("{}", msg))]
     Server { status: Status, msg: String },
 
     #[snafu(display("Illegal Database response: {err_msg}"))]
-    IllegalDatabaseResponse { err_msg: String },
+    IllegalDatabaseResponse {
+        err_msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Failed to send request with streaming: {}", err_msg))]
-    ClientStreaming { err_msg: String, location: Location },
+    ClientStreaming {
+        err_msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Failed to parse ascii string: {}", value))]
     InvalidAscii {

--- a/src/load_balance.rs
+++ b/src/load_balance.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use enum_dispatch::enum_dispatch;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 
 #[enum_dispatch]
 pub trait LoadBalance {
@@ -37,7 +37,7 @@ pub struct Random;
 
 impl LoadBalance for Random {
     fn get_peer<'a>(&self, peers: &'a [String]) -> Option<&'a String> {
-        peers.choose(&mut rand::thread_rng())
+        peers.choose(&mut rand::rng())
     }
 }
 


### PR DESCRIPTION
This pr mainly upgrade `greptime-proto` from v0.7.0 to v0.9.0, which keep the proto version consistent with that used by the go sdk and java sdk.

Also, upgrade `dashmap`, `greptime-proto`, `rand`, `snafu`, `derive-new`.
