### PR TITLE
fix: handle stream end

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,16 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Response stream ended unexpectedly with pending requests: {:?}",
+        request_ids
+    ))]
+    StreamEndedWithPendingRequests {
+        request_ids: Vec<i64>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
         "Request timeout after {:?} for request IDs: {:?}",
         timeout,
         request_ids


### PR DESCRIPTION
Ensure that the next request can immediately return an error when the stream exception ends.