### PR TITLE
feat!: make rustls-backed TLS an opt-in feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ snafu = "0.8"
 tokio = { version = "1.40", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["io-util", "compat"] }
-tonic = { version = "0.14", features = ["tls-ring", "gzip", "zstd"] }
+tonic = { version = "0.14", features = ["gzip", "zstd"] }
 tower = "0.5"
 derive_builder = "0.20"
 toml = "0.9.8"
@@ -74,6 +74,11 @@ required-features = ["integration-tests"]
 [features]
 default = []
 integration-tests = []
+# Opt-in rustls-backed TLS. Without this feature the client is
+# plaintext-only and the dependency graph contains no rustls, which lets
+# downstreams with a system-native-TLS-only policy (or a trusted local
+# hop) consume the row API.
+tls-ring = ["tonic/tls-ring"]
 
 [profile.release]
 debug = true

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -19,15 +19,19 @@ use std::time::Duration;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use lazy_static::lazy_static;
-use snafu::{OptionExt, ResultExt};
+#[cfg(feature = "tls-ring")]
+use snafu::OptionExt;
+use snafu::ResultExt;
 use tokio_util::sync::CancellationToken;
 use tonic::codec::CompressionEncoding;
-use tonic::transport::{
-    Certificate, Channel as InnerChannel, ClientTlsConfig, Endpoint, Identity, Uri,
-};
+#[cfg(feature = "tls-ring")]
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+use tonic::transport::{Channel as InnerChannel, Endpoint, Uri};
 use tower::Service;
 
-use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
+use crate::error::{CreateChannelSnafu, Result};
+#[cfg(feature = "tls-ring")]
+use crate::error::{InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
 pub const DEFAULT_GRPC_REQUEST_TIMEOUT_SECS: u64 = 10;
@@ -48,6 +52,7 @@ pub struct ChannelManager {
 struct Inner {
     id: u64,
     config: ChannelConfig,
+    #[cfg(feature = "tls-ring")]
     client_tls_config: Option<ClientTlsConfig>,
     pool: Arc<Pool>,
     channel_recycle_started: AtomicBool,
@@ -76,6 +81,7 @@ impl Inner {
         Self {
             id,
             config,
+            #[cfg(feature = "tls-ring")]
             client_tls_config: None,
             pool,
             channel_recycle_started: AtomicBool::new(false),
@@ -100,6 +106,7 @@ impl ChannelManager {
         }
     }
 
+    #[cfg(feature = "tls-ring")]
     pub fn with_tls_config(config: ChannelConfig) -> Result<Self> {
         let mut inner = Inner::with_config(config.clone());
 
@@ -198,11 +205,14 @@ impl ChannelManager {
     }
 
     fn build_endpoint(&self, addr: &str) -> Result<Endpoint> {
+        #[cfg(feature = "tls-ring")]
         let http_prefix = if self.inner.client_tls_config.is_some() {
             "https"
         } else {
             "http"
         };
+        #[cfg(not(feature = "tls-ring"))]
+        let http_prefix = "http";
 
         let mut endpoint =
             Endpoint::new(format!("{http_prefix}://{addr}")).context(CreateChannelSnafu)?;
@@ -237,6 +247,7 @@ impl ChannelManager {
         if let Some(enabled) = self.config().http2_adaptive_window {
             endpoint = endpoint.http2_adaptive_window(enabled);
         }
+        #[cfg(feature = "tls-ring")]
         if let Some(tls_config) = &self.inner.client_tls_config {
             endpoint = endpoint
                 .tls_config(tls_config.clone())

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,11 @@ use snafu::OptionExt;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 
-use crate::channel_manager::{ChannelConfig, ChannelManager, ClientTlsOption};
+#[cfg(any(test, feature = "tls-ring"))]
+use crate::channel_manager::ChannelConfig;
+use crate::channel_manager::ChannelManager;
+#[cfg(feature = "tls-ring")]
+use crate::channel_manager::ClientTlsOption;
 use crate::load_balance::{LoadBalance, Loadbalancer};
 use crate::{error, Result};
 
@@ -59,6 +63,7 @@ impl Client {
         Self::with_manager_and_urls(ChannelManager::new(), urls)
     }
 
+    #[cfg(feature = "tls-ring")]
     pub fn with_tls_and_urls<U, A>(urls: A, client_tls: ClientTlsOption) -> Result<Self>
     where
         U: AsRef<str>,


### PR DESCRIPTION
## What

The manifest unconditionally enables tonic's `tls-ring` feature, so every consumer carries a rustls/tokio-rustls dependency — even when connecting over plaintext to a trusted local endpoint, or when their organization mandates the operating system's native TLS stack and forbids bundled rustls trust roots.

This PR makes TLS **opt-in** via a new `tls-ring` crate feature that forwards to `tonic/tls-ring`:

- Without the feature the client is plaintext-only: `Certificate`/`Identity`/`ClientTlsConfig` imports, the `client_tls_config` channel state, `ChannelManager::with_tls_config`, and `Client::with_tls_and_urls` are `cfg`-gated, and endpoint URLs are always `http`.
- `ClientTlsOption` and `ChannelConfig::client_tls` stay available unconditionally so configuration parsing does not change shape.
- With `--features tls-ring` everything behaves exactly as before.

## Verification

- `cargo check`/`cargo test --no-default-features`: green, and `cargo tree -i rustls` / `-i tokio-rustls` match **no packages**
- `cargo check`/`cargo test --features tls-ring`: green
- `cargo check`/`cargo test` (default features): green
- `cargo fmt --check`, `cargo clippy --no-default-features`: clean

## Note on compatibility

This changes the implicit default: consumers relying on TLS today need to enable the `tls-ring` feature explicitly. If you prefer to keep backward compatibility, an alternative is `default = ["tls-ring"]` — plaintext consumers would then use `default-features = false`. Happy to switch to that shape if you prefer.

Context: we ship an observability tool ([Parallax](https://github.com/tailrocks/parallax)) with a strict native-TLS-only dependency policy and a plaintext trusted local hop to a managed GreptimeDB; the unconditional rustls edge is currently the only thing keeping us on the HTTP SQL path instead of the row API. A follow-up we'd also be interested in contributing is a native-TLS connector via `Endpoint::connect_with_connector_lazy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)