### PR TITLE
feat(bulk): attach auto-create table metadata to Arrow schema

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -74,12 +74,13 @@ pub type RequestId = i64;
 
 /// Arrow field metadata key carrying the GreptimeDB semantic type of a column
 /// (`timestamp`, `tag` or `field`). Attached to every field of the bulk insert
-/// Arrow schema so that the server can auto-create the table on first write.
+/// Arrow schema so that the server can auto-create the table on first write
+/// (GreptimeDB Enterprise Flight bulk auto-create contract).
 pub const GREPTIME_SEMANTIC_TYPE_KEY: &str = "greptime:semantic_type";
 
 /// Arrow field metadata key carrying the extended GreptimeDB column type for
 /// types that do not round-trip through Arrow (e.g. `Json`, which is encoded
-/// as Arrow `Binary`).
+/// as Arrow `Binary`). Must not be set on the timestamp column.
 pub const GREPTIME_TYPE_KEY: &str = "greptime:type";
 
 /// High-level bulk inserter for `GreptimeDB`
@@ -196,6 +197,17 @@ impl BulkStreamWriter {
     ) -> Result<Self> {
         // Create the encoder with compression settings
         let encoder = FlightEncoder::with_compression(options.compression);
+
+        // The server auto-create contract allows exactly one timestamp column
+        ensure!(
+            table_schema
+                .columns()
+                .iter()
+                .filter(|col| col.semantic_type == SemanticType::Timestamp)
+                .count()
+                <= 1,
+            error::MultipleTimestampColumnsSnafu
+        );
 
         // Convert table schema to Arrow schema
         let fields: Result<Vec<Field>> = table_schema
@@ -709,7 +721,7 @@ fn column_to_arrow_field(column: &Column) -> Result<Field> {
         GREPTIME_SEMANTIC_TYPE_KEY.to_string(),
         semantic_type.to_string(),
     )]);
-    if column.data_type == ColumnDataType::Json {
+    if column.data_type == ColumnDataType::Json && column.semantic_type != SemanticType::Timestamp {
         metadata.insert(GREPTIME_TYPE_KEY.to_string(), "Json".to_string());
     }
     Ok(Field::new(&column.name, data_type, nullable).with_metadata(metadata))
@@ -1382,11 +1394,17 @@ impl<'a> RowBuilder<'a> {
 pub use crate::api::v1::ColumnDataType as ColumnType;
 
 fn find_timestamp_index_and_window(column_schemas: &[Column]) -> Result<(usize, i64)> {
-    let (timestamp_column_index, timestamp_type) = column_schemas
+    let mut timestamp_columns = column_schemas
         .iter()
         .enumerate()
-        .find(|(_, col)| col.semantic_type == SemanticType::Timestamp)
+        .filter(|(_, col)| col.semantic_type == SemanticType::Timestamp);
+    let (timestamp_column_index, timestamp_type) = timestamp_columns
+        .next()
         .context(error::MissingTimestampColumnSnafu)?;
+    ensure!(
+        timestamp_columns.next().is_none(),
+        error::MultipleTimestampColumnsSnafu
+    );
 
     let time_window_duration = match timestamp_type.data_type {
         ColumnDataType::TimestampSecond => 3600i64,
@@ -1731,6 +1749,15 @@ mod tests {
                 semantic_type: SemanticType::Field,
                 data_type_extension: None,
             },
+            Column {
+                name: "price".to_string(),
+                data_type: ColumnDataType::Decimal128,
+                semantic_type: SemanticType::Field,
+                data_type_extension: Some(DataTypeExtension::Decimal128 {
+                    precision: 20,
+                    scale: 4,
+                }),
+            },
         ];
 
         let rows = Rows::new(&schema, 1).expect("Failed to create rows");
@@ -1756,8 +1783,66 @@ mod tests {
                 .map(String::as_str),
             Some("Json")
         );
+        // Only the allowed metadata keys may be present: the server rejects any
+        // other `greptime:*` key in the auto-create path
+        for (idx, field) in fields.iter().enumerate() {
+            let expected_len = if idx == 3 { 2 } else { 1 };
+            assert_eq!(
+                field.metadata().len(),
+                expected_len,
+                "unexpected metadata keys on field `{}`",
+                field.name()
+            );
+        }
+        // Decimal128 precision/scale rides in the Arrow type and must not set
+        // `greptime:type`
         assert!(!fields[4].metadata().contains_key(GREPTIME_TYPE_KEY));
-        assert!(!fields[1].metadata().contains_key(GREPTIME_TYPE_KEY));
+        assert!(!fields[5].metadata().contains_key(GREPTIME_TYPE_KEY));
+    }
+
+    #[test]
+    fn test_multiple_timestamp_columns_rejected() {
+        let schema = vec![
+            Column {
+                name: "ts1".to_string(),
+                data_type: ColumnDataType::TimestampMillisecond,
+                semantic_type: SemanticType::Timestamp,
+                data_type_extension: None,
+            },
+            Column {
+                name: "ts2".to_string(),
+                data_type: ColumnDataType::TimestampMillisecond,
+                semantic_type: SemanticType::Timestamp,
+                data_type_extension: None,
+            },
+        ];
+
+        let err = Rows::new(&schema, 1).unwrap_err().to_string();
+        assert!(
+            err.contains("Multiple timestamp columns"),
+            "Actual: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_json_type_key_not_set_on_timestamp_column() {
+        let column = Column {
+            name: "ts".to_string(),
+            data_type: ColumnDataType::Json,
+            semantic_type: SemanticType::Timestamp,
+            data_type_extension: None,
+        };
+
+        let field = column_to_arrow_field(&column).expect("Failed to build field");
+        assert!(!field.metadata().contains_key(GREPTIME_TYPE_KEY));
+        assert_eq!(
+            field
+                .metadata()
+                .get(GREPTIME_SEMANTIC_TYPE_KEY)
+                .map(String::as_str),
+            Some("timestamp")
+        );
     }
 
     #[test]

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -72,6 +72,16 @@ where
 
 pub type RequestId = i64;
 
+/// Arrow field metadata key carrying the GreptimeDB semantic type of a column
+/// (`timestamp`, `tag` or `field`). Attached to every field of the bulk insert
+/// Arrow schema so that the server can auto-create the table on first write.
+pub const GREPTIME_SEMANTIC_TYPE_KEY: &str = "greptime:semantic_type";
+
+/// Arrow field metadata key carrying the extended GreptimeDB column type for
+/// types that do not round-trip through Arrow (e.g. `Json`, which is encoded
+/// as Arrow `Binary`).
+pub const GREPTIME_TYPE_KEY: &str = "greptime:type";
+
 /// High-level bulk inserter for `GreptimeDB`
 #[derive(Clone, Debug)]
 pub struct BulkInserter {
@@ -191,11 +201,7 @@ impl BulkStreamWriter {
         let fields: Result<Vec<Field>> = table_schema
             .columns()
             .iter()
-            .map(|col| {
-                let nullable = col.semantic_type != SemanticType::Timestamp;
-                column_to_arrow_data_type(col)
-                    .map(|data_type| Field::new(&col.name, data_type, nullable))
-            })
+            .map(column_to_arrow_field)
             .collect();
         let arrow_schema = Arc::new(Schema::new(fields?));
 
@@ -688,6 +694,27 @@ impl BulkStreamWriter {
     }
 }
 
+/// Convert a table column to an Arrow field, attaching the GreptimeDB metadata
+/// (`greptime:semantic_type` and, for extended types like JSON, `greptime:type`)
+/// that the server uses to auto-create the table on bulk insert.
+fn column_to_arrow_field(column: &Column) -> Result<Field> {
+    let data_type = column_to_arrow_data_type(column)?;
+    let nullable = column.semantic_type != SemanticType::Timestamp;
+    let semantic_type = match column.semantic_type {
+        SemanticType::Timestamp => "timestamp",
+        SemanticType::Tag => "tag",
+        SemanticType::Field => "field",
+    };
+    let mut metadata = HashMap::from([(
+        GREPTIME_SEMANTIC_TYPE_KEY.to_string(),
+        semantic_type.to_string(),
+    )]);
+    if column.data_type == ColumnDataType::Json {
+        metadata.insert(GREPTIME_TYPE_KEY.to_string(), "Json".to_string());
+    }
+    Ok(Field::new(&column.name, data_type, nullable).with_metadata(metadata))
+}
+
 // Helper function to convert ColumnDataType to Arrow DataType
 // Based on GreptimeDB Java implementation - only supports actually implemented types
 fn column_to_arrow_data_type(column: &Column) -> Result<DataType> {
@@ -982,15 +1009,10 @@ impl RowBatchBuilder {
         let mut fields = Vec::with_capacity(column_schemas.len());
         let mut timestamp_index_opt = None;
         for (idx, col) in column_schemas.iter().enumerate() {
-            let mut nullable = true;
             if col.semantic_type == SemanticType::Timestamp {
-                nullable = false;
                 timestamp_index_opt = Some(idx);
             }
-
-            let field = column_to_arrow_data_type(col)
-                .map(|data_type| Field::new(&col.name, data_type, nullable))?;
-            fields.push(field);
+            fields.push(column_to_arrow_field(col)?);
         }
         let schema = Arc::new(Schema::new(fields));
 
@@ -1674,6 +1696,93 @@ mod tests {
         assert_eq!(Rows::window_initial_capacity(0), 0);
         assert_eq!(Rows::window_initial_capacity(32), 32);
         assert_eq!(Rows::window_initial_capacity(10_000), 1024);
+    }
+
+    #[test]
+    fn test_arrow_fields_carry_greptime_metadata() {
+        let schema = vec![
+            Column {
+                name: "host".to_string(),
+                data_type: ColumnDataType::String,
+                semantic_type: SemanticType::Tag,
+                data_type_extension: None,
+            },
+            Column {
+                name: "ts".to_string(),
+                data_type: ColumnDataType::TimestampMillisecond,
+                semantic_type: SemanticType::Timestamp,
+                data_type_extension: None,
+            },
+            Column {
+                name: "value".to_string(),
+                data_type: ColumnDataType::Float64,
+                semantic_type: SemanticType::Field,
+                data_type_extension: None,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: ColumnDataType::Json,
+                semantic_type: SemanticType::Field,
+                data_type_extension: None,
+            },
+            Column {
+                name: "raw".to_string(),
+                data_type: ColumnDataType::Binary,
+                semantic_type: SemanticType::Field,
+                data_type_extension: None,
+            },
+        ];
+
+        let rows = Rows::new(&schema, 1).expect("Failed to create rows");
+        let fields = rows.schema().fields();
+
+        let semantic_type_of = |idx: usize| {
+            fields[idx]
+                .metadata()
+                .get(GREPTIME_SEMANTIC_TYPE_KEY)
+                .cloned()
+        };
+        assert_eq!(semantic_type_of(0).as_deref(), Some("tag"));
+        assert_eq!(semantic_type_of(1).as_deref(), Some("timestamp"));
+        assert_eq!(semantic_type_of(2).as_deref(), Some("field"));
+
+        assert!(!fields[1].is_nullable());
+        assert!(fields[0].is_nullable());
+
+        assert_eq!(
+            fields[3]
+                .metadata()
+                .get(GREPTIME_TYPE_KEY)
+                .map(String::as_str),
+            Some("Json")
+        );
+        assert!(!fields[4].metadata().contains_key(GREPTIME_TYPE_KEY));
+        assert!(!fields[1].metadata().contains_key(GREPTIME_TYPE_KEY));
+    }
+
+    #[test]
+    fn test_record_batch_schema_carries_greptime_metadata() {
+        let schema = create_timestamp_schema(ColumnDataType::TimestampMillisecond);
+        let mut rows = Rows::new(&schema, 2).expect("Failed to create rows");
+        add_rows(&mut rows, ColumnDataType::TimestampMillisecond, &[(0, 1)]);
+
+        let batches: Vec<RecordBatchWithTimestamp> =
+            rows.try_into().expect("Failed to convert rows");
+        let batch_schema = batches[0].batch().schema();
+        assert_eq!(
+            batch_schema.fields()[0]
+                .metadata()
+                .get(GREPTIME_SEMANTIC_TYPE_KEY)
+                .map(String::as_str),
+            Some("timestamp")
+        );
+        assert_eq!(
+            batch_schema.fields()[1]
+                .metadata()
+                .get(GREPTIME_SEMANTIC_TYPE_KEY)
+                .map(String::as_str),
+            Some("field")
+        );
     }
 
     // Helper function to create a simple schema with timestamp and value columns

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -83,6 +83,8 @@ pub const GREPTIME_SEMANTIC_TYPE_KEY: &str = "greptime:semantic_type";
 /// as Arrow `Binary`). Must not be set on the timestamp column.
 pub const GREPTIME_TYPE_KEY: &str = "greptime:type";
 
+const AUTO_CREATE_TABLE_HINT_KEY: &str = "auto_create_table";
+
 /// High-level bulk inserter for `GreptimeDB`
 #[derive(Clone, Debug)]
 pub struct BulkInserter {
@@ -113,6 +115,23 @@ impl BulkInserter {
     ) -> Result<BulkStreamWriter> {
         let options = options.unwrap_or_default();
         BulkStreamWriter::new(&self.database, table_schema, options).await
+    }
+
+    /// Create a bulk stream writer and explicitly control automatic table creation.
+    pub async fn create_bulk_stream_writer_with_auto_create_table(
+        &self,
+        table_schema: &TableSchema,
+        options: Option<BulkWriteOptions>,
+        auto_create_table: bool,
+    ) -> Result<BulkStreamWriter> {
+        let options = options.unwrap_or_default();
+        BulkStreamWriter::new_with_auto_create_table(
+            &self.database,
+            table_schema,
+            options,
+            auto_create_table,
+        )
+        .await
     }
 }
 
@@ -166,6 +185,11 @@ impl BulkWriteOptions {
     }
 }
 
+fn auto_create_table_hint(auto_create_table: bool) -> (&'static str, &'static str) {
+    let value = if auto_create_table { "true" } else { "false" };
+    (AUTO_CREATE_TABLE_HINT_KEY, value)
+}
+
 /// High-performance bulk stream writer that maintains a persistent connection
 /// Each writer is bound to a specific table with fixed schema
 pub struct BulkStreamWriter {
@@ -194,6 +218,17 @@ impl BulkStreamWriter {
         database: &Database,
         table_schema: &TableSchema,
         options: BulkWriteOptions,
+    ) -> Result<Self> {
+        Self::new_with_auto_create_table(database, table_schema, options, false).await
+    }
+
+    /// Create a writer and explicitly control automatic table creation.
+    /// The server's global auto-create setting must also be enabled.
+    pub async fn new_with_auto_create_table(
+        database: &Database,
+        table_schema: &TableSchema,
+        options: BulkWriteOptions,
+        auto_create_table: bool,
     ) -> Result<Self> {
         // Create the encoder with compression settings
         let encoder = FlightEncoder::with_compression(options.compression);
@@ -234,7 +269,8 @@ impl BulkStreamWriter {
 
         // Convert receiver to a stream and start the do_put operation
         let flight_stream = receiver.boxed();
-        let response_stream = database.do_put(flight_stream).await?;
+        let hints = [auto_create_table_hint(auto_create_table)];
+        let response_stream = database.do_put_with_hints(flight_stream, &hints).await?;
 
         Ok(Self {
             sender,
@@ -1481,6 +1517,15 @@ mod tests {
             "Actual: {}",
             rows2_err_msg
         );
+    }
+
+    #[test]
+    fn test_auto_create_table_hint_values() {
+        assert_eq!(
+            auto_create_table_hint(false),
+            ("auto_create_table", "false")
+        );
+        assert_eq!(auto_create_table_hint(true), ("auto_create_table", "true"));
     }
 
     #[test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -134,6 +134,32 @@ impl Database {
     /// Ingest a stream of [RecordBatch]es that belong to a table, using Arrow Flight's "`DoPut`"
     /// method. The return value is also a stream, produces [DoPutResponse]s.
     pub async fn do_put(&self, stream: FlightDataStream) -> Result<DoPutResponseStream> {
+        self.do_put_with_hints(stream, &[]).await
+    }
+
+    /// Ingest a stream of [RecordBatch]es with request hints using Arrow Flight's "`DoPut`".
+    pub(crate) async fn do_put_with_hints(
+        &self,
+        stream: FlightDataStream,
+        hints: &[(&str, &str)],
+    ) -> Result<DoPutResponseStream> {
+        let request = self.do_put_request(stream, hints)?;
+
+        let mut client = self.client.make_flight_client()?;
+        let response = client.mut_inner().do_put(request).await?;
+        let response = response
+            .into_inner()
+            .map_err(Into::into)
+            .and_then(|x| future::ready(DoPutResponse::try_from(x)))
+            .boxed();
+        Ok(response)
+    }
+
+    fn do_put_request(
+        &self,
+        stream: FlightDataStream,
+        hints: &[(&str, &str)],
+    ) -> Result<tonic::Request<FlightDataStream>> {
         let mut request = tonic::Request::new(stream);
 
         if let Some(AuthHeader {
@@ -153,15 +179,8 @@ impl Database {
             consts::REQUEST_METADATA_KEY_DATABASE_NAME,
             MetadataValue::from_str(&self.dbname).context(error::InvalidTonicMetadataValueSnafu)?,
         );
-
-        let mut client = self.client.make_flight_client()?;
-        let response = client.mut_inner().do_put(request).await?;
-        let response = response
-            .into_inner()
-            .map_err(Into::into)
-            .and_then(|x| future::ready(DoPutResponse::try_from(x)))
-            .boxed();
-        Ok(response)
+        Self::put_hints(request.metadata_mut(), hints)?;
+        Ok(request)
     }
 
     async fn handle(&self, request: Request, hints: &[(&str, &str)]) -> Result<u32> {
@@ -210,5 +229,51 @@ impl Database {
             AsciiMetadataValue::from_str(&value).context(error::InvalidTonicMetadataValueSnafu)?;
         metadata.insert(key, value);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[test]
+    fn test_do_put_request_contains_auth_database_and_hints() {
+        let mut database = Database::new_with_dbname("metrics", Client::new());
+        database.set_auth(AuthScheme::Basic(Basic {
+            username: "user".to_string(),
+            password: "pass".to_string(),
+        }));
+        let stream = stream::empty().boxed();
+
+        let request = database
+            .do_put_request(stream, &[("auto_create_table", "false")])
+            .unwrap();
+        let metadata = request.metadata();
+
+        assert_eq!(
+            metadata
+                .get(consts::REQUEST_METADATA_KEY_HINTS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "auto_create_table=false"
+        );
+        assert_eq!(
+            metadata
+                .get(consts::REQUEST_METADATA_KEY_DATABASE_NAME)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "metrics"
+        );
+        assert_eq!(
+            metadata
+                .get(consts::REQUEST_METADATA_KEY_AUTH)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Basic dXNlcjpwYXNz"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,6 +192,12 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Multiple timestamp columns in schema. Exactly one column with SemanticType::Timestamp is allowed"))]
+    MultipleTimestampColumns {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Timestamp value is null. Timestamp columns cannot contain null values"))]
     NullTimestamp {
         #[snafu(implicit)]


### PR DESCRIPTION
## Summary

Aligns the Rust bulk writer with the latest GreptimeDB Enterprise Flight bulk auto-create contract from GreptimeTeam/greptimedb-enterprise#845 (HEAD `9b277b5b`).

The client now provides both parts required by the server:

- Strict Arrow field metadata describing the schema to create
- The Flight request hint that explicitly enables or disables automatic creation

## API

Existing constructors remain source-compatible and default automatic table creation to disabled:

```rust
let writer = inserter
    .create_bulk_stream_writer(&schema, options)
    .await?;
```

Use the new constructor to enable it for a writer:

```rust
let writer = inserter
    .create_bulk_stream_writer_with_auto_create_table(&schema, options, true)
    .await?;
```

The client sends `x-greptime-hints: auto_create_table=true|false`. A true hint only takes effect when automatic table creation is also enabled globally on the server.

## Changes

- Attach `greptime:semantic_type` (`timestamp`/`tag`/`field`) to every Arrow field
- Emit `greptime:type: Json` for JSON fields encoded as Arrow `Binary`, never on the timestamp field
- Reject schemas containing multiple timestamp columns before opening the stream
- Add source-compatible explicit auto-create constructors to `BulkInserter` and `BulkStreamWriter`; existing constructors send false
- Forward `auto_create_table` through the shared `x-greptime-hints` metadata while preserving database and authentication headers

## Testing

- Verify semantic metadata values, allowed key cardinality, JSON/Binary/Decimal128 behavior, and multiple-timestamp rejection
- Verify exact true/false hint pairs
- Verify the constructed Flight request contains hint, database, and Basic authentication metadata
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test -- --skip integration` (47 tests passed)